### PR TITLE
Add user migration rake task from aact-admin to v2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ DB_PASSWORD=password
 
 AACT_CORE_DB_URL=postgres://rails:password@localhost:5432/aact
 AACT_PUBLIC_DB_URL=postgres://rails:password@localhost:5432/aact_public
+AACT_ADMIN_DB_URL=postgres://rails:password@localhost:5432/aact_admin
 
 LOGS_SERVER_HOST=138.197.44.53
 LOGS_SERVER_USER=root

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -40,7 +40,7 @@ class Admin::UsersController < Admin::BaseController
           user.admin?,
           user.database_creation_status,
           user.created_at&.strftime("%Y-%m-%d"),
-          user.migrated_at&.strftime("%Y-%m-%d")
+          user.migrated?
         ]
       end
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,48 @@
 class Admin::UsersController < Admin::BaseController
   def index
-    @users = User.order(created_at: :desc)
+    scope = User
+      .search(search_param)
+      .order(created_at: :desc)
+
+    @pagy, @users = pagy(scope, limit: 20)
+
+    render :results if turbo_frame_request?
+  end
+
+  def download_csv
+    scope = User
+      .search(search_param)
+      .order(created_at: :desc)
+
+    users = scope.limit(10_000)
+    csv_data = generate_csv(users)
+
+    send_data csv_data,
+              filename: "aact_users_#{Time.current.strftime('%Y%m%d')}.csv",
+              type: "text/csv"
+  end
+
+  private
+
+  def search_param
+    params[:search]&.strip&.slice(0, 100)
+  end
+
+  def generate_csv(users)
+    require "csv"
+    CSV.generate(headers: true) do |csv|
+      csv << %w[Name Email DB_Username Admin DB_Status Joined Migrated]
+      users.each do |user|
+        csv << [
+          user.name,
+          user.email_address,
+          user.database_username,
+          user.admin?,
+          user.database_creation_status,
+          user.created_at&.strftime("%Y-%m-%d"),
+          user.migrated_at&.strftime("%Y-%m-%d")
+        ]
+      end
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,14 @@ class User < ApplicationRecord
 
   has_many :sessions, dependent: :destroy
 
+  scope :search, ->(term) {
+    return all if term.blank?
+    where(
+      "name ILIKE :q OR email_address ILIKE :q OR database_username ILIKE :q",
+      q: "%#{term}%"
+    )
+  }
+
   encrypts :database_password, deterministic: false
 
   attr_readonly :admin

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -4,70 +4,31 @@
     <p class="text-gray-600">Manage application users</p>
   </div>
 
-  <div class="bg-white shadow rounded-lg overflow-hidden">
-    <div class="px-6 py-4 border-b border-gray-200">
-      <h2 class="text-lg font-semibold text-gray-900">All Users (<%= @users.count %>)</h2>
-    </div>
-
-    <div class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
-          <tr>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">User</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Admin</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">DB Access</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">DB Username</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Joined</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Migrated</th>
-          </tr>
-        </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
-          <% @users.each do |user| %>
-            <tr>
-              <td class="px-6 py-4 whitespace-nowrap">
-                <div class="text-sm font-medium text-gray-900"><%= user.name %></div>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                <%= user.email_address %>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap">
-                <% if user.admin? %>
-                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                    Admin
-                  </span>
-                <% else %>
-                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-                    User
-                  </span>
-                <% end %>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap">
-                <% if user.has_database_credentials? %>
-                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                    Active
-                  </span>
-                <% else %>
-                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
-                    Not Set Up
-                  </span>
-                <% end %>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                <%= user.database_username.present? ? user.database_username : '-' %>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                <%= user.created_at.strftime("%m/%d/%Y") %>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                <%= user.migrated_at.present? ? user.migrated_at.strftime("%m/%d/%Y") : '-' %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
+  <!-- Search -->
+  <div class="mb-6 bg-white p-4 rounded-lg shadow">
+    <%= form_with url: admin_users_path, method: :get, data: { turbo_frame: "admin_users_results" } do |f| %>
+      <div class="flex gap-4 items-end">
+        <div class="flex-1">
+          <%= f.label :search, "Search", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.text_field :search,
+              value: params[:search],
+              placeholder: "Search by name, email, or database username...",
+              maxlength: 100,
+              class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        </div>
+        <div class="flex gap-2">
+          <%= f.submit "Search", class: "px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer" %>
+          <button type="button"
+                  onclick="const form = this.closest('form'); const input = form.querySelector('input[name=search]'); input.value = ''; form.requestSubmit();"
+                  class="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400">
+            Clear
+          </button>
+        </div>
+      </div>
+    <% end %>
   </div>
+
+  <%= render template: "admin/users/results" %>
 
   <div class="mt-8">
     <%= link_to "Back to Dashboard", root_path, class: "text-gray-700 underline hover:no-underline" %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,7 +1,6 @@
 <div class="mx-auto max-w-6xl">
   <div class="mb-8">
     <h1 class="text-3xl font-bold text-gray-900 mb-2">Admin - Users</h1>
-    <p class="text-gray-600">Manage application users</p>
   </div>
 
   <!-- Search -->

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -19,6 +19,7 @@
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">DB Access</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">DB Username</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Joined</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Migrated</th>
           </tr>
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
@@ -56,7 +57,10 @@
                 <%= user.database_username.present? ? user.database_username : '-' %>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                <%= user.created_at.strftime("%B %d, %Y") %>
+                <%= user.created_at.strftime("%m/%d/%Y") %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <%= user.migrated_at.present? ? user.migrated_at.strftime("%m/%d/%Y") : '-' %>
               </td>
             </tr>
           <% end %>

--- a/app/views/admin/users/results.html.erb
+++ b/app/views/admin/users/results.html.erb
@@ -60,7 +60,11 @@
               <%= user.created_at.strftime("%m/%d/%Y") %>
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-              <%= user.migrated_at.present? ? user.migrated_at.strftime("%m/%d/%Y") : "-" %>
+              <% if user.migrated? %>
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">Yes</span>
+              <% else %>
+                -
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/app/views/admin/users/results.html.erb
+++ b/app/views/admin/users/results.html.erb
@@ -1,0 +1,75 @@
+<%= turbo_frame_tag "admin_users_results" do %>
+  <!-- Results Header with Download -->
+  <div class="mb-4 flex justify-between items-center">
+    <p class="text-sm text-gray-600">
+      <%== @pagy.info_tag %>
+    </p>
+    <%= link_to download_csv_admin_users_path(search: params[:search]),
+                class: "inline-flex items-center px-3 py-1.5 text-sm bg-green-600 text-white rounded-md hover:bg-green-700",
+                data: { turbo: false } do %>
+      <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>
+      </svg>
+      Download CSV
+    <% end %>
+  </div>
+
+  <!-- Results Table -->
+  <div class="bg-white shadow rounded-lg overflow-hidden overflow-x-auto">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-gray-50">
+        <tr>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">User</th>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Admin</th>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">DB Access</th>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Joined</th>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Migrated</th>
+        </tr>
+      </thead>
+      <tbody class="bg-white divide-y divide-gray-200">
+        <% @users.each do |user| %>
+          <tr class="hover:bg-gray-50">
+            <td class="px-6 py-4 whitespace-nowrap">
+              <div class="text-sm font-medium text-gray-900"><%= user.name %></div>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+              <%= user.email_address %>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap">
+              <% if user.admin? %>
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                  Admin
+                </span>
+              <% else %>
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+                  User
+                </span>
+              <% end %>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+              <% if user.database_username.present? %>
+                <%= user.database_username %>
+              <% else %>
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+                  Not Set Up
+                </span>
+              <% end %>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              <%= user.created_at.strftime("%m/%d/%Y") %>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              <%= user.migrated_at.present? ? user.migrated_at.strftime("%m/%d/%Y") : "-" %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Pagination -->
+  <div class="mt-6 flex justify-center">
+    <%== @pagy.series_nav %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,7 @@
               <%= link_to "Documentation", documentation_index_path, class: "text-sm text-gray-700 hover:text-blue-600" %>
 
               <% if Current.user&.admin? %>
-                <%= link_to "Admin", admin_users_path, class: "text-sm text-gray-700 hover:text-blue-600" %>
+                <%= link_to "Users", admin_users_path, class: "text-sm text-gray-700 hover:text-blue-600" %>
                 <%= link_to "CTGov", admin_ctgov_metadata_path, class: "text-sm text-gray-700 hover:text-blue-600" %>
               <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,11 @@ Rails.application.routes.draw do
 
   # Admin routes
   namespace :admin do
-    resources :users, only: [ :index ]
+    resources :users, only: [ :index ] do
+      collection do
+        get :download_csv
+      end
+    end
     resources :ctgov_metadata, only: [ :index ] do
       collection do
         post :sync

--- a/db/migrate/20260215120000_add_migrated_at_and_constraints_to_users.rb
+++ b/db/migrate/20260215120000_add_migrated_at_and_constraints_to_users.rb
@@ -1,0 +1,7 @@
+class AddMigratedAtAndConstraintsToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :migrated_at, :timestamp
+    add_index :users, :database_username, unique: true
+    change_column_null :users, :name, false
+  end
+end

--- a/db/migrate/20260219151943_replace_migrated_at_with_migrated_and_add_metadata_to_users.rb
+++ b/db/migrate/20260219151943_replace_migrated_at_with_migrated_and_add_metadata_to_users.rb
@@ -1,0 +1,7 @@
+class ReplaceMigratedAtWithMigratedAndAddMetadataToUsers < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :users, :migrated_at, :timestamp
+    add_column :users, :migrated, :boolean, default: false, null: false
+    add_column :users, :metadata, :jsonb
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,9 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
+# Load seed files in alphabetical order.
+# Each file should be idempotent (safe to run multiple times).
 #
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# Usage:
+#   bin/rails db:seed        — run seeds standalone
+#   bin/rails db:setup       — create + schema + seed (fresh start)
+#   bin/rails db:reset       — drop + create + schema + seed (nuke & rebuild)
+
+Dir[Rails.root.join("db/seeds/*.rb")].sort.each { |f| require f }

--- a/db/seeds/01_users.rb
+++ b/db/seeds/01_users.rb
@@ -1,0 +1,94 @@
+# Seed users with varied data for local development.
+# Covers: short/long names, different email formats, mixed DB access states,
+# varied join dates, and migrated vs. non-migrated users.
+#
+# Admin login: admin_user@example.com / admin_user
+
+puts "Seeding users..."
+
+if Rails.env.production?
+  puts "  Skipping user seeding in production environment."
+  return
+end
+
+# --- Admin ---
+User.find_or_create_by!(email_address: "admin_user@example.com") do |u|
+  u.name = "Admin User"
+  u.password = "admin_user"
+  u.admin = true
+  u.database_username = "admin_db"
+  u.database_password = "fake_db_password"
+  u.database_creation_status = "completed"
+  u.migrated_at = 2.months.ago
+  u.created_at = 1.year.ago
+end
+
+# --- Regular users with hand-picked variety ---
+users_data = [
+  # Short names
+  { name: "Li Wei",         email: "li.wei@university.edu",              joined: 11.months.ago, migrated: 3.months.ago, db_user: "li_wei",      db_status: "completed" },
+  { name: "Ana Ruiz",       email: "ana@clinic.org",                     joined: 10.months.ago, migrated: 2.months.ago, db_user: "ana_ruiz",    db_status: "completed" },
+  { name: "Jo Kim",         email: "jo@research.io",                     joined: 9.months.ago,  migrated: nil,          db_user: nil,           db_status: "not_requested" },
+
+  # Long names
+  { name: "Dr. Alexander Mikhailovich Petrov-Sokolovsky", email: "alexander.petrov-sokolovsky@longname-university-hospital.edu", joined: 8.months.ago, migrated: 1.month.ago, db_user: "a_petrov_sokolovsky", db_status: "completed" },
+  { name: "Maria Guadalupe Hernandez de la Cruz",        email: "mghernandez@centro-investigacion.mx",                          joined: 7.months.ago, migrated: nil,         db_user: nil,                   db_status: "not_requested" },
+
+  # Various DB statuses
+  { name: "Priya Sharma",       email: "priya.sharma@biotech.com",       joined: 6.months.ago,  migrated: 1.month.ago,  db_user: "priya_s",     db_status: "completed" },
+  { name: "James Okonkwo",      email: "j.okonkwo@hospital.ng",          joined: 6.months.ago,  migrated: nil,          db_user: nil,           db_status: "pending" },
+  { name: "Sarah Mitchell",     email: "smitchell@pharma-research.com",  joined: 5.months.ago,  migrated: nil,          db_user: nil,           db_status: "processing" },
+  { name: "Yuki Tanaka",        email: "yuki.tanaka@med.ac.jp",          joined: 5.months.ago,  migrated: nil,          db_user: nil,           db_status: "failed" },
+
+  # Typical researchers
+  { name: "Emily Chen",         email: "echen@stanford.edu",             joined: 4.months.ago,  migrated: 2.weeks.ago,  db_user: "echen",       db_status: "completed" },
+  { name: "Robert Williams",    email: "rwilliams@mayo.edu",             joined: 4.months.ago,  migrated: nil,          db_user: nil,           db_status: "not_requested" },
+  { name: "Fatima Al-Hassan",   email: "falhassan@kau.edu.sa",           joined: 3.months.ago,  migrated: 1.week.ago,   db_user: "falhassan",   db_status: "completed" },
+  { name: "David Park",         email: "dpark@nih.gov",                  joined: 3.months.ago,  migrated: nil,          db_user: "dpark",       db_status: "completed" },
+  { name: "Olga Novikova",      email: "olga.novikova@msu.ru",           joined: 2.months.ago,  migrated: nil,          db_user: nil,           db_status: "not_requested" },
+  { name: "Carlos Mendez",      email: "cmendez@unam.mx",               joined: 2.months.ago,  migrated: nil,          db_user: nil,           db_status: "pending" },
+
+  # Common names for testing duplicates/searches
+  { name: "John Doe",           email: "john.doe@example.com",           joined: 3.weeks.ago,   migrated: nil,          db_user: nil,           db_status: "not_requested" },
+  { name: "John Doe",           email: "jdoe@test.org",                 joined: 2.weeks.ago,   migrated: nil,          db_user: nil,           db_status: "not_requested" },
+  { name: "John Smith",         email: "john.smith@example.com",        joined: 1.week.ago,    migrated: nil,          db_user: nil,           db_status: "not_requested" },
+
+  # Repeatable domains for search testing
+  { name: "Alice Johnson",      email: "alice@example.com",             joined: 10.days.ago,   migrated: nil,          db_user: nil,           db_status: "not_requested" },
+  { name: "Bob Brown",          email: "bob@example.com",               joined: 5.days.ago,    migrated: nil,          db_user: nil,           db_status: "not_requested" },
+  { name: "Charlie Wilson",     email: "charlie@test.org",              joined: 3.days.ago,    migrated: nil,          db_user: nil,           db_status: "not_requested" },
+
+  # Recent signups (no DB access, not migrated)
+  { name: "Aisha Patel",        email: "aisha.p@gmail.com",              joined: 3.weeks.ago,   migrated: nil,          db_user: nil,           db_status: "not_requested" },
+  { name: "Tom O'Brien",        email: "tobrien@partners.org",           joined: 2.weeks.ago,   migrated: nil,          db_user: nil,           db_status: "not_requested" },
+  { name: "Mei-Ling Wu",        email: "mlwu@ntu.edu.tw",               joined: 10.days.ago,   migrated: nil,          db_user: nil,           db_status: "not_requested" },
+  { name: "Hans Gruber",        email: "hgruber@charite.de",             joined: 1.week.ago,    migrated: nil,          db_user: nil,           db_status: "not_requested" },
+  { name: "Nina Petrova",       email: "nina.p@karolinska.se",           joined: 5.days.ago,    migrated: nil,          db_user: nil,           db_status: "not_requested" },
+
+  # Edge cases: long emails, special characters
+  { name: "Jean-Pierre Dubois", email: "jean-pierre.dubois@institut-pasteur.fr",  joined: 45.days.ago,  migrated: nil,  db_user: nil,          db_status: "not_requested" },
+  { name: "Saoirse O'Sullivan", email: "sosullivan@rcsi.ie",                      joined: 40.days.ago,  migrated: nil,  db_user: "sosullivan", db_status: "completed" },
+  { name: "Björk Sigurdsson",   email: "bjork@landspitali.is",                    joined: 35.days.ago,  migrated: nil,  db_user: nil,          db_status: "not_requested" },
+
+  # Very old account
+  { name: "Patricia Thompson",  email: "pthompson@duke.edu",             joined: 2.years.ago,   migrated: 6.months.ago, db_user: "pthompson",   db_status: "completed" },
+
+  # Brand new
+  { name: "Raj Kapoor",         email: "raj.kapoor@aiims.edu.in",        joined: 1.day.ago,     migrated: nil,          db_user: nil,           db_status: "not_requested" }
+]
+
+users_data.each do |data|
+  User.find_or_create_by!(email_address: data[:email]) do |u|
+    u.name = data[:name]
+    u.password = "password"
+    u.database_username = data[:db_user]
+    u.database_password = "fake_db_password" if data[:db_user].present?
+    u.database_creation_status = data[:db_status]
+    u.migrated_at = data[:migrated]
+    u.created_at = data[:joined]
+  end
+end
+
+puts "  #{User.count} users total (#{User.where(admin: true).count} admin)"
+admin_user = User.find_by(admin: true)
+puts "Admin login for development: #{admin_user&.email_address} / admin_user" if admin_user

--- a/db/seeds/01_users.rb
+++ b/db/seeds/01_users.rb
@@ -19,7 +19,7 @@ User.find_or_create_by!(email_address: "admin_user@example.com") do |u|
   u.database_username = "admin_db"
   u.database_password = "fake_db_password"
   u.database_creation_status = "completed"
-  u.migrated_at = 2.months.ago
+  u.migrated = true
   u.created_at = 1.year.ago
 end
 
@@ -84,7 +84,7 @@ users_data.each do |data|
     u.database_username = data[:db_user]
     u.database_password = "fake_db_password" if data[:db_user].present?
     u.database_creation_status = data[:db_status]
-    u.migrated_at = data[:migrated]
+    u.migrated = data[:migrated].present?
     u.created_at = data[:joined]
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -252,7 +252,8 @@ CREATE TABLE public.users (
     database_creation_status character varying DEFAULT 'not_requested'::character varying NOT NULL,
     database_creation_error text,
     database_creation_attempted_at timestamp(6) without time zone,
-    migrated_at timestamp without time zone
+    migrated boolean DEFAULT false NOT NULL,
+    metadata jsonb
 );
 
 
@@ -585,6 +586,7 @@ ALTER TABLE ONLY public.sessions
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260219151943'),
 ('20260215120000'),
 ('20251209120000'),
 ('20251126135835'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -245,13 +245,14 @@ CREATE TABLE public.users (
     password_digest character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    name character varying,
+    name character varying NOT NULL,
     admin boolean DEFAULT false NOT NULL,
     database_username character varying,
     database_password character varying,
     database_creation_status character varying DEFAULT 'not_requested'::character varying NOT NULL,
     database_creation_error text,
-    database_creation_attempted_at timestamp(6) without time zone
+    database_creation_attempted_at timestamp(6) without time zone,
+    migrated_at timestamp without time zone
 );
 
 
@@ -535,6 +536,13 @@ CREATE INDEX index_users_on_database_creation_status ON public.users USING btree
 
 
 --
+-- Name: index_users_on_database_username; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_users_on_database_username ON public.users USING btree (database_username);
+
+
+--
 -- Name: index_users_on_email_address; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -577,6 +585,7 @@ ALTER TABLE ONLY public.sessions
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260215120000'),
 ('20251209120000'),
 ('20251126135835'),
 ('20251028004756'),

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,94 @@
+namespace :users do
+  desc "Test connection to aact-admin database"
+  task test_admin_connection: :environment do
+    url = ENV.fetch("AACT_ADMIN_DB_URL") { abort "AACT_ADMIN_DB_URL is not set" }
+
+    conn = PG.connect(url)
+    count = conn.exec("SELECT COUNT(*) FROM ctgov.users").first["count"]
+    puts "Connected to aact-admin. Found #{count} users in ctgov.users."
+  ensure
+    conn&.close
+  end
+
+  desc "Migrate users from aact-admin to aact-v2 (upsert by email)"
+  task migrate_from_admin: :environment do
+    url = ENV.fetch("AACT_ADMIN_DB_URL") { abort "AACT_ADMIN_DB_URL is not set" }
+
+    conn = PG.connect(url)
+
+    rows = conn.exec(<<~SQL)
+      SELECT email, encrypted_password, first_name, last_name, username, admin,
+             confirmed_at, sign_in_count, current_sign_in_at, last_sign_in_at,
+             current_sign_in_ip, last_sign_in_ip, db_activity, last_db_activity,
+             created_at
+      FROM ctgov.users
+    SQL
+
+    source_count = rows.ntuples
+    created = 0
+    updated = 0
+    errors = []
+
+    rows.each_with_index do |row, index|
+      email = row["email"].to_s.strip.downcase
+      if email.blank?
+        errors << "row #{index + 1}: (blank email) — Email can't be blank"
+        next
+      end
+
+      first = row["first_name"].to_s.strip
+      last = row["last_name"].to_s.strip
+      name = "#{first} #{last}".strip
+      name = email.split("@").first if name.blank?
+
+      username = row["username"].to_s.strip.presence
+
+      metadata = {
+        first_name: first.presence,
+        last_name: last.presence,
+        admin: row["admin"],
+        confirmed_at: row["confirmed_at"],
+        sign_in_count: row["sign_in_count"],
+        current_sign_in_at: row["current_sign_in_at"],
+        last_sign_in_at: row["last_sign_in_at"],
+        current_sign_in_ip: row["current_sign_in_ip"],
+        last_sign_in_ip: row["last_sign_in_ip"],
+        db_activity: row["db_activity"],
+        last_db_activity: row["last_db_activity"]
+      }.compact
+
+      user = User.find_by(email_address: email)
+      is_new = user.nil?
+      user ||= User.new(email_address: email)
+
+      user.name = name
+      user.database_username = username
+      user.migrated = true
+      user.metadata = metadata
+      user.password_digest = row["encrypted_password"]
+      user.created_at = row["created_at"] if is_new
+
+      user.save!
+
+      is_new ? created += 1 : updated += 1
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+      errors << "row #{index + 1}: #{email} — #{e.message}"
+    end
+
+    conn.close
+
+    puts <<~SUMMARY
+
+      === Migration Summary ===
+      Source (aact-admin):  #{source_count} users
+      Created:              #{created}
+      Updated:              #{updated}
+      Errors:               #{errors.size}
+    SUMMARY
+
+    if errors.any?
+      puts "Errors:"
+      errors.each { |e| puts "  - #{e}" }
+    end
+  end
+end


### PR DESCRIPTION
  Summary

  - Add users:migrate_from_admin rake task that upserts ~10K users from aact-admin (ctgov.users) into v2 via raw PG connection
  - Bcrypt password hashes copy directly — existing passwords work without reset
  - Legacy Devise fields (sign-in tracking, admin flag, confirmed_at, db_activity) stored in metadata jsonb column
  - Replace migrated_at timestamp with migrated boolean flag
  - Add searchable, paginated admin user list with CSV export
  - Development seeds with realistic user variety

  Test plan

  - bin/rails users:test_admin_connection — prints user count
  - bin/rails users:migrate_from_admin — creates/updates users, prints summary
  - Re-run task — all users updated (upsert, no duplicates)
  - Log in as migrated user with old password
  - Visit /admin/users — migrated users visible with badge
  - bin/rails test — passes
