### PR TITLE
Promote first/last name to columns + add legacy DB pointer

### DIFF
--- a/app/jobs/sync_users_job.rb
+++ b/app/jobs/sync_users_job.rb
@@ -12,7 +12,7 @@ class SyncUsersJob < ApplicationJob
 
     rows = conn.exec(<<~SQL)
       SELECT
-        email, encrypted_password,
+        id, email, encrypted_password,
         remember_created_at,
         sign_in_count, current_sign_in_at, last_sign_in_at,
         current_sign_in_ip, last_sign_in_ip,
@@ -37,7 +37,6 @@ class SyncUsersJob < ApplicationJob
         next
       end
 
-      # TODO: update logic when lastname added as separate field to the user schema
       first = row["first_name"].to_s.strip
       last = row["last_name"].to_s.strip
       name = "#{first} #{last}".strip
@@ -46,6 +45,7 @@ class SyncUsersJob < ApplicationJob
       username = row["username"].to_s.strip.presence
 
       metadata = {
+        id: row["id"],
         first_name: first.presence,
         last_name: last.presence,
         admin: row["admin"],
@@ -67,14 +67,15 @@ class SyncUsersJob < ApplicationJob
       is_new = user.nil?
       user ||= User.new(email_address: email)
 
+      user.legacy_user_id = row["id"]
+      user.first_name = first.presence
+      user.last_name = last.presence
       user.name = name
       user.database_username = username
       user.migrated = true
       user.metadata = metadata
       user.password_digest = row["encrypted_password"]
-      # TEMP: is_new guard removed for one-time correction of existing migrated users.
-      # Restore `is_new &&` after first successful prod sync to lock created_at after that.
-      user.created_at = row["account_created_at"] if row["account_created_at"].present?
+      user.created_at = row["account_created_at"] if is_new && row["account_created_at"].present?
 
       user.save!
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,8 +24,11 @@ class User < ApplicationRecord
   attr_readonly :admin
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
+  normalizes :first_name, :last_name, with: ->(v) { v&.strip.presence }
 
   validates :email_address, presence: true, uniqueness: true
+  validates :first_name, presence: true, length: { maximum: 50 }
+  validates :last_name, presence: true, length: { maximum: 50 }
   validates :name, presence: true
   validates :database_username, uniqueness: true, allow_blank: true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 require "sidekiq/web"
+require "sidekiq/cron/web"
 
 Rails.application.routes.draw do
   # Authentication routes

--- a/db/migrate/20260425231615_add_fields_to_users.rb
+++ b/db/migrate/20260425231615_add_fields_to_users.rb
@@ -1,0 +1,6 @@
+class AddFieldsToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :first_name, :string, limit: 50
+    add_column :users, :last_name, :string, limit: 50
+  end
+end

--- a/db/migrate/20260425231615_add_fields_to_users.rb
+++ b/db/migrate/20260425231615_add_fields_to_users.rb
@@ -2,5 +2,7 @@ class AddFieldsToUsers < ActiveRecord::Migration[8.0]
   def change
     add_column :users, :first_name, :string, limit: 50
     add_column :users, :last_name, :string, limit: 50
+    add_column :users, :legacy_user_id, :bigint
+    add_index :users, :legacy_user_id, unique: true, where: "legacy_user_id IS NOT NULL"
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -291,7 +291,8 @@ CREATE TABLE public.users (
     migrated boolean DEFAULT false NOT NULL,
     metadata jsonb,
     first_name character varying(50),
-    last_name character varying(50)
+    last_name character varying(50),
+    legacy_user_id bigint
 );
 
 
@@ -629,6 +630,13 @@ CREATE UNIQUE INDEX index_users_on_database_username ON public.users USING btree
 --
 
 CREATE UNIQUE INDEX index_users_on_email_address ON public.users USING btree (email_address);
+
+
+--
+-- Name: index_users_on_legacy_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_users_on_legacy_user_id ON public.users USING btree (legacy_user_id) WHERE (legacy_user_id IS NOT NULL);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -289,7 +289,9 @@ CREATE TABLE public.users (
     database_creation_error text,
     database_creation_attempted_at timestamp(6) without time zone,
     migrated boolean DEFAULT false NOT NULL,
-    metadata jsonb
+    metadata jsonb,
+    first_name character varying(50),
+    last_name character varying(50)
 );
 
 
@@ -673,6 +675,7 @@ ALTER TABLE ONLY public.sessions
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260425231615'),
 ('20260327210756'),
 ('20260327015820'),
 ('20260219151943'),


### PR DESCRIPTION
  - Splits name into proper first_name / last_name columns so the app can read each part directly.                                                                                   
  - Replaces the eventual need to keep growing the metadata jsonb blob with a legacy_user_id  pointer to ctgov.users — fresh, structured data on demand instead of a stale snapshot.      
  - metadata stays populated for now to help debug account-creation issues during the migration window; cleanup comes once readers move to legacy_user_id lookups.                
  - Adds the sidekiq-cron tab to the existing /sidekiq mount so scheduled jobs are visible and manually triggerable.                                                                      
                  