### PR TITLE
Split user name into first/last on signup and profile   

### DIFF
--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -19,6 +19,6 @@ class Settings::ProfilesController < ApplicationController
   private
 
   def profile_params
-    params.expect(user: [ :name, :email_address ])
+    params.expect(user: [ :first_name, :last_name, :email_address ])
   end
 end

--- a/app/controllers/sign_ups_controller.rb
+++ b/app/controllers/sign_ups_controller.rb
@@ -21,6 +21,6 @@ class SignUpsController < ApplicationController
   private
 
   def sign_up_params
-    params.expect(user: [ :name, :email_address, :password, :password_confirmation ])
+    params.expect(user: [ :first_name, :last_name, :email_address, :password, :password_confirmation ])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,8 @@ class User < ApplicationRecord
   normalizes :email_address, with: ->(e) { e.strip.downcase }
   normalizes :first_name, :last_name, with: ->(v) { v&.strip.presence }
 
+  before_validation :set_full_name
+
   validates :email_address, presence: true, uniqueness: true
   validates :first_name, presence: true, length: { maximum: 50 }
   validates :last_name, presence: true, length: { maximum: 50 }
@@ -41,5 +43,12 @@ class User < ApplicationRecord
   # Check if user has database credentials
   def has_database_credentials?
     database_username.present? && database_password.present?
+  end
+
+  private
+
+  def set_full_name
+    return unless first_name.present? || last_name.present?
+    self.name = "#{first_name} #{last_name}".strip
   end
 end

--- a/app/views/settings/profiles/show.html.erb
+++ b/app/views/settings/profiles/show.html.erb
@@ -9,10 +9,18 @@
 
 <%= form_with model: @user, url: settings_profile_path, method: :patch, class: "space-y-6" do |form| %>
   <div>
-    <%= form.label :name, "Name", class: "block text-sm font-medium text-gray-700 mb-2" %>
-    <%= form.text_field :name, 
-          required: true, 
-          autocomplete: "name",
+    <%= form.label :first_name, "First Name", class: "block text-sm font-medium text-gray-700 mb-2" %>
+    <%= form.text_field :first_name,
+          required: true,
+          autocomplete: "given-name",
+          class: "block w-full sm:w-96 px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+  </div>
+
+  <div>
+    <%= form.label :last_name, "Last Name", class: "block text-sm font-medium text-gray-700 mb-2" %>
+    <%= form.text_field :last_name,
+          required: true,
+          autocomplete: "family-name",
           class: "block w-full sm:w-96 px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
   </div>
 

--- a/app/views/sign_ups/show.html.erb
+++ b/app/views/sign_ups/show.html.erb
@@ -3,7 +3,11 @@
 
   <%= form_with model: @user, url: sign_up_path, class: "contents" do |form| %>
     <div class="my-5">
-      <%= form.text_field :name, required: true, autofocus: true, autocomplete: "name", placeholder: "Enter your name", class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+      <%= form.text_field :first_name, required: true, autofocus: true, autocomplete: "given-name", placeholder: "Enter your first name", class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+    </div>
+
+    <div class="my-5">
+      <%= form.text_field :last_name, required: true, autocomplete: "family-name", placeholder: "Enter your last name", class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="my-5">

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,7 +3,13 @@
 one:
   email_address: one@example.com
   password_digest: <%= password_digest %>
+  first_name: One
+  last_name: Example
+  name: One Example
 
 two:
   email_address: two@example.com
   password_digest: <%= password_digest %>
+  first_name: Two
+  last_name: Example
+  name: Two Example

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,64 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def build_user(**overrides)
+    User.new(
+      email_address: "new@example.com",
+      first_name: "Test",
+      last_name: "User",
+      password: "secretpw1",
+      password_confirmation: "secretpw1",
+      **overrides
+    )
+  end
+
+  test "set_full_name derives name from first_name and last_name" do
+    user = build_user
+    user.valid?
+    assert_equal "Test User", user.name
+  end
+
+  test "set_full_name strips surrounding whitespace from inputs" do
+    user = build_user(first_name: "  Test  ", last_name: "  User  ")
+    user.valid?
+    assert_equal "Test User", user.name
+  end
+
+  test "first_name presence is required" do
+    user = build_user(first_name: nil)
+    assert_not user.valid?
+    assert_includes user.errors[:first_name], "can't be blank"
+  end
+
+  test "last_name presence is required" do
+    user = build_user(last_name: nil)
+    assert_not user.valid?
+    assert_includes user.errors[:last_name], "can't be blank"
+  end
+
+  test "first_name is invalid when blank or whitespace-only" do
+    [ "", "   " ].each do |value|
+      user = build_user(first_name: value)
+      assert_not user.valid?, "expected first_name=#{value.inspect} to be invalid"
+      assert_includes user.errors[:first_name], "can't be blank"
+    end
+  end
+
+  test "last_name is invalid when blank or whitespace-only" do
+    [ "", "   " ].each do |value|
+      user = build_user(last_name: value)
+      assert_not user.valid?, "expected last_name=#{value.inspect} to be invalid"
+      assert_includes user.errors[:last_name], "can't be blank"
+    end
+  end
+
+  test "first_name length is capped at 50" do
+    user = build_user(first_name: "a" * 51)
+    assert_not user.valid?
+    assert_includes user.errors[:first_name], "is too long (maximum is 50 characters)"
+  end
+
+  test "valid user saves successfully" do
+    assert build_user.save
+  end
 end


### PR DESCRIPTION
  Schema already had `first_name`/`last_name` — this wires them into the signup and profile forms.                                                                                      
                                                                                              
  Keeping `name` populated via a `before_validation` callback so admin views, search, and CSV export keep working. Readers will migrate off `name` in follow-up PRs, then we drop it.