### PR TITLE
Add Playground Usage admin page  

### DIFF
--- a/app/controllers/admin/playground_controller.rb
+++ b/app/controllers/admin/playground_controller.rb
@@ -1,0 +1,36 @@
+class Admin::PlaygroundController < Admin::BaseController
+  def index
+    @end_date = parse_date(params[:end_date], Date.current)
+    @start_date = parse_date(params[:start_date], @end_date - 9.days)
+
+    service = PlaygroundAnalyticsService.new(start_date: @start_date, end_date: @end_date)
+    result = service.daily_metrics
+    @metrics = result[:metrics]
+
+    compute_summary_stats
+  end
+
+  private
+
+  def parse_date(value, fallback)
+    value.present? ? Date.parse(value) : fallback
+  rescue Date::Error
+    fallback
+  end
+
+  def compute_summary_stats
+    return if @metrics.blank?
+
+    totals = @metrics.map { |m| m[:total] }
+    @total_queries = totals.sum
+    @avg_queries_per_day = (@total_queries.to_f / totals.size).round
+    @max_queries_per_day = totals.max
+
+    @total_completed = @metrics.sum { |m| m[:completed] }
+    @total_errors = @metrics.sum { |m| m[:errors] }
+    @completion_rate = @total_queries.positive? ? (@total_completed.to_f / @total_queries * 100).round(1) : 0
+
+    users = @metrics.map { |m| m[:unique_users] }
+    @avg_users_per_day = (users.sum.to_f / users.size).round
+  end
+end

--- a/app/models/aact/playground_query.rb
+++ b/app/models/aact/playground_query.rb
@@ -1,0 +1,11 @@
+module Aact
+  class PlaygroundQuery < ApplicationRecord
+    self.table_name = "public.background_jobs"
+    self.inheritance_column = :_type_disabled
+
+    establish_connection :external
+
+    DB_QUERY_TYPE = "BackgroundJob::DbQuery".freeze
+    default_scope { where(type: DB_QUERY_TYPE) }
+  end
+end

--- a/app/services/playground_analytics_service.rb
+++ b/app/services/playground_analytics_service.rb
@@ -1,0 +1,33 @@
+class PlaygroundAnalyticsService
+  def initialize(start_date: nil, end_date: nil)
+    @start_date = start_date&.to_date || 9.days.ago.to_date
+    @end_date = end_date&.to_date || Date.current
+  end
+
+  def daily_metrics
+    rows = Aact::PlaygroundQuery
+      .where(created_at: @start_date.beginning_of_day..@end_date.end_of_day)
+      .group("DATE(created_at)")
+      .order(Arel.sql("DATE(created_at) DESC"))
+      .pluck(Arel.sql(<<~SQL))
+        DATE(created_at) AS day,
+        COUNT(*) AS total,
+        COUNT(DISTINCT user_id) AS unique_users,
+        COUNT(*) FILTER (WHERE status = 'complete') AS completed,
+        COUNT(*) FILTER (WHERE status = 'error')    AS errors
+      SQL
+
+    {
+      date_range: { start: @start_date, end: @end_date },
+      metrics: rows.map do |day, total, unique_users, completed, errors|
+        {
+          date: day.to_date,
+          total: total,
+          unique_users: unique_users,
+          completed: completed,
+          errors: errors
+        }
+      end
+    }
+  end
+end

--- a/app/views/admin/playground/index.html.erb
+++ b/app/views/admin/playground/index.html.erb
@@ -1,0 +1,93 @@
+<div class="mx-auto max-w-6xl">
+  <h1 class="text-3xl font-bold text-gray-900 mb-8 text-center">Playground Queries</h1>
+
+  <!-- Date Range Selector -->
+  <div class="bg-white shadow rounded-lg p-6 mb-6">
+    <h2 class="text-sm font-medium text-gray-700 mb-3">Select Date Range</h2>
+    <%= form_tag admin_playground_path, method: :get, class: "flex items-end gap-4" do %>
+      <div>
+        <%= label_tag :start_date, "Start Date", class: "block text-sm text-gray-600 mb-1" %>
+        <%= date_field_tag :start_date, @start_date, class: "block w-full rounded-md border-gray-300 shadow-sm text-sm" %>
+      </div>
+      <div>
+        <%= label_tag :end_date, "End Date", class: "block text-sm text-gray-600 mb-1" %>
+        <%= date_field_tag :end_date, @end_date, class: "block w-full rounded-md border-gray-300 shadow-sm text-sm" %>
+      </div>
+      <div>
+        <%= submit_tag "Apply", class: "px-6 py-2 bg-navy text-white text-sm font-medium rounded-md hover:bg-navy/90 cursor-pointer" %>
+      </div>
+    <% end %>
+  </div>
+
+  <% if @metrics.present? %>
+    <!-- Playground Summary -->
+    <div class="bg-white shadow rounded-lg p-6 mb-6">
+      <h2 class="text-sm font-medium text-gray-700 mb-4">
+        Playground Summary: <%= @start_date.strftime("%b %d, %Y") %> - <%= @end_date.strftime("%b %d, %Y") %> (<%= @metrics.size %> days)
+      </h2>
+      <div class="grid grid-cols-3 gap-4 mb-4">
+        <div class="border border-navy/20 rounded-lg p-4 text-center">
+          <div class="text-sm text-gray-500 mb-1">Total Queries</div>
+          <div class="text-xl font-bold"><%= number_with_delimiter(@total_queries) %></div>
+        </div>
+        <div class="border border-navy/20 rounded-lg p-4 text-center">
+          <div class="text-sm text-gray-500 mb-1">Completed</div>
+          <div class="text-xl font-bold"><%= number_with_delimiter(@total_completed) %></div>
+        </div>
+        <div class="border border-navy/20 rounded-lg p-4 text-center">
+          <div class="text-sm text-gray-500 mb-1">Errors</div>
+          <div class="text-xl font-bold"><%= number_with_delimiter(@total_errors) %></div>
+        </div>
+      </div>
+      <div class="grid grid-cols-3 gap-4">
+        <div class="border border-navy/20 rounded-lg p-4 text-center">
+          <div class="text-sm text-gray-500 mb-1">Completion Rate</div>
+          <div class="text-xl font-bold"><%= @completion_rate %>%</div>
+        </div>
+        <div class="border border-navy/20 rounded-lg p-4 text-center">
+          <div class="text-sm text-gray-500 mb-1">Avg Queries/Day</div>
+          <div class="text-xl font-bold"><%= number_with_delimiter(@avg_queries_per_day) %></div>
+        </div>
+        <div class="border border-navy/20 rounded-lg p-4 text-center">
+          <div class="text-sm text-gray-500 mb-1">Avg Users/Day</div>
+          <div class="text-xl font-bold"><%= number_with_delimiter(@avg_users_per_day) %></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Daily Metrics Table -->
+    <div class="bg-white shadow rounded-lg overflow-hidden">
+      <div class="px-6 py-4 flex justify-between items-center border-b border-navy/20">
+        <h2 class="text-sm font-medium text-navy">Daily Playground Activity</h2>
+        <span class="text-xs text-gray-500">Sourced from aact-core background_jobs (legacy admin playground).</span>
+      </div>
+      <table class="min-w-full divide-y divide-navy/10">
+        <thead class="bg-navy/5">
+          <tr>
+            <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase">Date</th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Total</th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Unique Users</th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Completed</th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Errors</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-navy/10">
+          <% @metrics.each do |metric| %>
+            <tr class="hover:bg-gray-50">
+              <td class="px-6 py-3 text-center text-sm text-gray-900"><%= metric[:date].strftime("%b %d, %Y") %></td>
+              <td class="px-6 py-3 text-right text-sm text-gray-900"><%= number_with_delimiter(metric[:total]) %></td>
+              <td class="px-6 py-3 text-right text-sm text-gray-900"><%= number_with_delimiter(metric[:unique_users]) %></td>
+              <td class="px-6 py-3 text-right text-sm text-gray-900"><%= number_with_delimiter(metric[:completed]) %></td>
+              <td class="px-6 py-3 text-right text-sm text-gray-900"><%= number_with_delimiter(metric[:errors]) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-6">
+      <h3 class="text-lg font-medium text-yellow-800 mb-2">No Data Available</h3>
+      <p class="text-yellow-700">No playground activity found for the selected date range.</p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,8 @@
 
               <% if Current.user&.admin? %>
                 <%= link_to "Users", admin_users_path, class: "text-sm text-gray-700 hover:text-blue-600" %>
-                <%= link_to "Usage", admin_usage_path, class: "text-sm text-gray-700 hover:text-blue-600" %>
+                <%= link_to "DB Usage", admin_usage_path, class: "text-sm text-gray-700 hover:text-blue-600" %>
+                <%= link_to "Playground Usage", admin_playground_path, class: "text-sm text-gray-700 hover:text-blue-600" %>
                 <%= link_to "Downloads Stats", admin_downloads_path, class: "text-sm text-gray-700 hover:text-blue-600" %>
                 <%= link_to "CTGov", admin_ctgov_metadata_path, class: "text-sm text-gray-700 hover:text-blue-600" %>
               <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
     get "usage", to: "usage#index"
     get "usage/:date", to: "usage#show", as: :daily_usage
     get "downloads", to: "downloads#index"
+    get "playground", to: "playground#index"
     resources :ctgov_metadata, only: [ :index ] do
       collection do
         post :sync


### PR DESCRIPTION
 - Reads aact-core's public.background_jobs directly via the existing :external connection — no ingestion path, no new v2     
table.
- Mirrors the usage/downloads pattern: 10-day default range, summary cards, daily table (Date / Total / Unique Users / Completed / Errors).
- Index-only for now; when v2 eventually owns the playground, the read path stays — only the writer changes.                      
- Renamed admin nav (Usage → DB Usage, added Playground Usage) and grouped the two stats links together.