### PR TITLE
Add Ahoy visit tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,16 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# First-party analytics — visits and events
+gem "ahoy_matey"
+# Ahoy requires when Ahoy.geocode = true
+gem "geocoder"
+
+group :production do
+  # Trusts Cloudflare's IP ranges so request.remote_ip returns the real client IP
+  gem "cloudflare-rails"
+end
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,11 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    ahoy_matey (5.5.0)
+      activesupport (>= 7.2)
+      cgi
+      device_detector (>= 1)
+      safely_block (>= 0.4)
     ast (2.4.2)
     base64 (0.3.0)
     bcrypt (3.1.20)
@@ -94,6 +99,12 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.5.1)
+    cloudflare-rails (7.0.0)
+      actionpack (>= 7.2.0, < 8.2.0)
+      activesupport (>= 7.2.0, < 8.2.0)
+      railties (>= 7.2.0, < 8.2.0)
+      zeitwerk (>= 2.5.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     crass (1.0.6)
@@ -105,6 +116,7 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    device_detector (1.1.3)
     dotenv (3.1.4)
     dotenv-rails (3.1.4)
       dotenv (= 3.1.4)
@@ -136,6 +148,9 @@ GEM
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
+    geocoder (1.8.6)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -302,6 +317,7 @@ GEM
       rubocop-rails
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
+    safely_block (1.0.0)
     securerandom (0.4.1)
     selenium-webdriver (4.25.0)
       base64 (~> 0.2)
@@ -382,16 +398,19 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  ahoy_matey
   bcrypt (~> 3.1.7)
   bootsnap
   brakeman
   capybara
+  cloudflare-rails
   csv
   debug
   dotenv-rails
   faraday (~> 2.7)
   faraday-retry
   faraday-typhoeus
+  geocoder
   importmap-rails
   jbuilder
   next_rails

--- a/app/controllers/api/v1/analytics_controller.rb
+++ b/app/controllers/api/v1/analytics_controller.rb
@@ -4,6 +4,8 @@ module Api
       # Skip authentication for API endpoints (server-to-server)
       allow_unauthenticated_access
 
+      skip_before_action :track_ahoy_visit
+
       before_action :set_date_params, only: [ :database_usage, :user_usage ]
       before_action :set_service, only: [ :database_usage, :user_usage ]
 

--- a/app/controllers/api/v1/documentation_controller.rb
+++ b/app/controllers/api/v1/documentation_controller.rb
@@ -9,6 +9,7 @@ module Api
       # TODO: review before deploying
       # Completely skips CSRF verification for all actions in this controller
       skip_before_action :verify_authenticity_token
+      skip_before_action :track_ahoy_visit
 
       before_action :setup_documentation_service
 

--- a/app/controllers/api/v1/internal_controller.rb
+++ b/app/controllers/api/v1/internal_controller.rb
@@ -1,7 +1,9 @@
 module Api
   module V1
     class InternalController < ApplicationController
+      # TODO: use with other legacy admin controllers
       allow_unauthenticated_access
+      skip_before_action :track_ahoy_visit
       skip_before_action :verify_authenticity_token
       wrap_parameters false
 

--- a/app/controllers/api/v1/logs_controller.rb
+++ b/app/controllers/api/v1/logs_controller.rb
@@ -4,6 +4,7 @@ module Api
       # Skip authentication for API endpoints (server-to-server)
       allow_unauthenticated_access
 
+      skip_before_action :track_ahoy_visit
       skip_before_action :verify_authenticity_token, only: [ :process_json ]
 
       # POST /api/v1/logs/process_json

--- a/app/controllers/api/v1/snapshots_controller.rb
+++ b/app/controllers/api/v1/snapshots_controller.rb
@@ -4,6 +4,7 @@ module Api
       # Skip authentication for API endpoints (server-to-server)
       allow_unauthenticated_access
 
+      skip_before_action :track_ahoy_visit
       before_action :setup_snapshots_service
 
       def index

--- a/app/controllers/api/v2/data_mapping_controller.rb
+++ b/app/controllers/api/v2/data_mapping_controller.rb
@@ -6,6 +6,8 @@ module Api
       # Skip authentication for API endpoints (server-to-server)
       allow_unauthenticated_access
 
+      skip_before_action :track_ahoy_visit
+
       def index
         mappings = Ctgov::AactMapping.joins(:api_metadata)
         render json: mappings.to_json(include: :api_metadata)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include Authentication
   include Pagy::Method
+  # TODO: Does Pagy belongs to Application Controller?
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -1,0 +1,8 @@
+class Ahoy::Event < ApplicationRecord
+  include Ahoy::QueryMethods
+
+  self.table_name = "ahoy_events"
+
+  belongs_to :visit
+  belongs_to :user, optional: true
+end

--- a/app/models/ahoy/visit.rb
+++ b/app/models/ahoy/visit.rb
@@ -1,0 +1,6 @@
+class Ahoy::Visit < ApplicationRecord
+  self.table_name = "ahoy_visits"
+
+  has_many :events, class_name: "Ahoy::Event"
+  belongs_to :user, optional: true
+end

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -1,0 +1,10 @@
+class Ahoy::Store < Ahoy::DatabaseStore
+end
+
+# set to true for JavaScript tracking
+Ahoy.api = false
+
+# set to true for geocoding (and add the geocoder gem to your Gemfile)
+# we recommend configuring local geocoding as well
+# see https://github.com/ankane/ahoy#geocoding
+Ahoy.geocode = true

--- a/db/migrate/20260502022039_create_ahoy_visits_and_events.rb
+++ b/db/migrate/20260502022039_create_ahoy_visits_and_events.rb
@@ -1,0 +1,62 @@
+class CreateAhoyVisitsAndEvents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :ahoy_visits do |t|
+      t.string :visit_token
+      t.string :visitor_token
+
+      # the rest are recommended but optional
+      # simply remove any you don't want
+
+      # user
+      t.references :user
+
+      # standard
+      t.string :ip
+      t.text :user_agent
+      t.text :referrer
+      t.string :referring_domain
+      t.text :landing_page
+
+      # technology
+      t.string :browser
+      t.string :os
+      t.string :device_type
+
+      # location
+      t.string :country
+      t.string :region
+      t.string :city
+      t.float :latitude
+      t.float :longitude
+
+      # utm parameters
+      t.string :utm_source
+      t.string :utm_medium
+      t.string :utm_term
+      t.string :utm_content
+      t.string :utm_campaign
+
+      # native apps
+      t.string :app_version
+      t.string :os_version
+      t.string :platform
+
+      t.datetime :started_at
+    end
+
+    add_index :ahoy_visits, :visit_token, unique: true
+    add_index :ahoy_visits, [ :visitor_token, :started_at ]
+
+    create_table :ahoy_events do |t|
+      t.references :visit
+      t.references :user
+
+      t.string :name
+      t.jsonb :properties
+      t.datetime :time
+    end
+
+    add_index :ahoy_events, [ :name, :time ]
+    add_index :ahoy_events, :properties, using: :gin, opclass: :jsonb_path_ops
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -62,6 +62,92 @@ ALTER SEQUENCE public.aact_public_query_metrics_id_seq OWNED BY public.aact_publ
 
 
 --
+-- Name: ahoy_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ahoy_events (
+    id bigint NOT NULL,
+    visit_id bigint,
+    user_id bigint,
+    name character varying,
+    properties jsonb,
+    "time" timestamp(6) without time zone
+);
+
+
+--
+-- Name: ahoy_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ahoy_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ahoy_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ahoy_events_id_seq OWNED BY public.ahoy_events.id;
+
+
+--
+-- Name: ahoy_visits; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ahoy_visits (
+    id bigint NOT NULL,
+    visit_token character varying,
+    visitor_token character varying,
+    user_id bigint,
+    ip character varying,
+    user_agent text,
+    referrer text,
+    referring_domain character varying,
+    landing_page text,
+    browser character varying,
+    os character varying,
+    device_type character varying,
+    country character varying,
+    region character varying,
+    city character varying,
+    latitude double precision,
+    longitude double precision,
+    utm_source character varying,
+    utm_medium character varying,
+    utm_term character varying,
+    utm_content character varying,
+    utm_campaign character varying,
+    app_version character varying,
+    os_version character varying,
+    platform character varying,
+    started_at timestamp(6) without time zone
+);
+
+
+--
+-- Name: ahoy_visits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ahoy_visits_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ahoy_visits_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ahoy_visits_id_seq OWNED BY public.ahoy_visits.id;
+
+
+--
 -- Name: analytics_snapshot_downloads; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -357,6 +443,20 @@ ALTER TABLE ONLY public.aact_public_query_metrics ALTER COLUMN id SET DEFAULT ne
 
 
 --
+-- Name: ahoy_events id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ahoy_events ALTER COLUMN id SET DEFAULT nextval('public.ahoy_events_id_seq'::regclass);
+
+
+--
+-- Name: ahoy_visits id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ahoy_visits ALTER COLUMN id SET DEFAULT nextval('public.ahoy_visits_id_seq'::regclass);
+
+
+--
 -- Name: analytics_snapshot_downloads id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -411,6 +511,22 @@ ALTER TABLE ONLY snapshots.ctgov_metadata ALTER COLUMN id SET DEFAULT nextval('s
 
 ALTER TABLE ONLY public.aact_public_query_metrics
     ADD CONSTRAINT aact_public_query_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ahoy_events ahoy_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ahoy_events
+    ADD CONSTRAINT ahoy_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ahoy_visits ahoy_visits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ahoy_visits
+    ADD CONSTRAINT ahoy_visits_pkey PRIMARY KEY (id);
 
 
 --
@@ -490,6 +606,55 @@ ALTER TABLE ONLY snapshots.ctgov_metadata
 --
 
 CREATE UNIQUE INDEX index_aact_public_query_metrics_on_log_date_and_username ON public.aact_public_query_metrics USING btree (log_date, username);
+
+
+--
+-- Name: index_ahoy_events_on_name_and_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ahoy_events_on_name_and_time ON public.ahoy_events USING btree (name, "time");
+
+
+--
+-- Name: index_ahoy_events_on_properties; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ahoy_events_on_properties ON public.ahoy_events USING gin (properties jsonb_path_ops);
+
+
+--
+-- Name: index_ahoy_events_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ahoy_events_on_user_id ON public.ahoy_events USING btree (user_id);
+
+
+--
+-- Name: index_ahoy_events_on_visit_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ahoy_events_on_visit_id ON public.ahoy_events USING btree (visit_id);
+
+
+--
+-- Name: index_ahoy_visits_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ahoy_visits_on_user_id ON public.ahoy_visits USING btree (user_id);
+
+
+--
+-- Name: index_ahoy_visits_on_visit_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_ahoy_visits_on_visit_token ON public.ahoy_visits USING btree (visit_token);
+
+
+--
+-- Name: index_ahoy_visits_on_visitor_token_and_started_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ahoy_visits_on_visitor_token_and_started_at ON public.ahoy_visits USING btree (visitor_token, started_at);
 
 
 --
@@ -683,6 +848,7 @@ ALTER TABLE ONLY public.sessions
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260502022039'),
 ('20260425231615'),
 ('20260327210756'),
 ('20260327015820'),


### PR DESCRIPTION
- Adds Ahoy for visit analytics. Geocoding enabled (async via Sidekiq).                                                        
- Includes cloudflare-rails (prod only) so `request.remote_ip` returns the real client IP behind DO App Platform's Cloudflare edge — without it, every visit IP would be a Cloudflare range and geocoding would be useless.                                                        
- Auto-tracking is on; skipped on `/api/*` controllers. 